### PR TITLE
Resolves multiple issues

### DIFF
--- a/generate-dis.F
+++ b/generate-dis.F
@@ -156,7 +156,7 @@ c
 c
  2       continue
                print *,'iq,ifail,iaccept',iq,ifail,iaccept
-       stop
+C        stop
        end
 c
        subroutine get_xsec(ztar,atar,x,y,q2,w2,eps,gam,x_sec,F1p,F2p

--- a/generate-dis.F
+++ b/generate-dis.F
@@ -249,7 +249,7 @@ c
           integer jc,m,itotal
           DATA itotal /0/
           character*8  c8name
-          character*200  fname
+          character*500  fname
           integer*4 iran,now(3),ifilenum
           DATA ifilenum /1/
 c

--- a/generate-dis.F
+++ b/generate-dis.F
@@ -378,7 +378,7 @@ c
       cl_gridxsec=.FALSE.  ! don't read x-section grid
       cl_gridsf=.FALSE.  ! don't read struck function grid
       cl_gridwrite=.FALSE.  ! don't write the grid
-      cl_realxsec=.FALSE.  ! do the weighted generation by default
+      cl_realxsec=.TRUE.  ! do the weighted generation by default
       cl_xq2=.FALSE.       ! do x/y by default
       cl_docker=.FALSE.    ! set if 1 file is needed 
 c

--- a/generate-dis.F
+++ b/generate-dis.F
@@ -111,8 +111,8 @@ c define the electron
         e_prime=E_beam-nu
         p_prime=sqrt(e_prime*e_prime-em*em)
         s2=q2/(4.*E_beam*e_prime)
-        thetar=asin(sqrt(s2))*2.0
         if(s2.gt.1.0.or.s2.lt.0) goto 100         ! 0<sin^2<1
+        thetar=asin(sqrt(s2))*2.0
         px_el=p_prime*sin(thetar)*cos(fiel)
         py_el=p_prime*sin(thetar)*sin(fiel)
         pz_el=p_prime*cos(thetar)

--- a/generate-dis.F
+++ b/generate-dis.F
@@ -576,7 +576,7 @@ c23456789012345678901234567890123456789012345678901234567890123456789012
         print *,'  --xq2  .FALSE.   generate in x/y'
         print *,'  --xgrid  .FALSE.   use xsec grid'
         print *,'  --sfgrid  .FALSE.   use  F1F2 grid'
-        print *,'  --realxsec .FALSE. use real xsection'
+        print *,'  --realxsec .TRUE. use real xsection'
         print *,'  --xq2  .FALSE. use x/y generation by def.'
         print *,'  --writegrid  .FALSE.  dump the grid'
         print *,'  --rad  0   no radiation,1-read-grid,2-calc,3-create'

--- a/grid_oper.F
+++ b/grid_oper.F
@@ -98,7 +98,7 @@ C-----------------------------------------------------
       integer iostat,i,j,k,l,i1,j1,ix1,itotal
       real sxbmax,symax,ebeam
       real gam2,xa,ya,q2,q2a,xcalc,xcalc2,x_sec
-      character*200  pdffile,clasdispdf
+      character*500  pdffile,clasdispdf
 c
       inquire(file='xdata/xdata.json',exist=ex)
 c

--- a/grid_oper.F
+++ b/grid_oper.F
@@ -271,7 +271,7 @@ c
         enddo
         enddo
         close(25)
-        stop
+C         stop
         return
         end
 


### PR DESCRIPTION
This PR is motivated by @baltzell's troubleshooting regarding IEEE floating errors.

First, the divided by zero issue was caused when the rejection criteria, ```xsec/xsec_max``` is inf, because ```xsec_max``` is zero.
This occurred because both cl_realxsec and cl_gridxsec were 0 by default.
From cl_realxsec's comment, " ! do the weighted generation by default" and subroutine printvalues's comment, "print *,'realxsec .TRUE. use real xsection',cl_realxsec", I determined cl_realxsec's default value "FALSE" was a mistake.
Rather, I set up cl_realxsec to be TRUE by default.
I updated printusage and --help's output to print cl_realxsec's default value as TRUE too.

Second, then the true cl_realxsec triggers "clasdispdf" and "pdffile" to be read using $DISRAD_PDF. In CVMFS, $DISRAD_PDF is not set up yet, but I expect this to be very long. So I changed the character length to 500.

Third, ```s2=q2/(4.*E_beam*e_prime)``` should be an input of arcsin. (line 115 of [generate-dis.F](https://github.com/JeffersonLab/inclusive-dis-rad/blob/master/generate-dis.F)).
The line 114, which checks 0<s2<1 was actually called after the program performed arcsin.
This generates an underflow error, so I switched the order of line 114 and 115.

Finally, I commented out "stop", at the end of main program and grid_oper.F, because they are not necessary but only printing warnings.